### PR TITLE
fix log missing caller and stack trace info

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -87,7 +87,7 @@ func init() {
 		runtimeSyncer,
 		zapcore.InfoLevel,
 	)
-	Runtime = zap.New(runtimeCore, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
+	Runtime = zap.New(runtimeCore, zap.AddCaller())
 	RuntimeSugar = Runtime.Sugar()
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -83,21 +83,11 @@ func (mws *MutableWriteSyncer) Sync() error {
 func init() {
 	runtimeSyncer = NewMutableWriteSyncer(zapcore.Lock(zapcore.AddSync(os.Stdout)))
 	runtimeCore := zapcore.NewCore(
-		zapcore.NewJSONEncoder(zapcore.EncoderConfig{
-			TimeKey:        "ts",
-			LevelKey:       "level",
-			NameKey:        "logger",
-			CallerKey:      "caller",
-			MessageKey:     "msg",
-			StacktraceKey:  "stacktrace",
-			EncodeLevel:    zapcore.LowercaseLevelEncoder,
-			EncodeTime:     zapcore.ISO8601TimeEncoder,
-			EncodeDuration: zapcore.SecondsDurationEncoder,
-		}),
+		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
 		runtimeSyncer,
 		zapcore.InfoLevel,
 	)
-	Runtime = zap.New(runtimeCore)
+	Runtime = zap.New(runtimeCore, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
 	RuntimeSugar = Runtime.Sugar()
 }
 


### PR DESCRIPTION
Signed-off-by: ChenQingya <qingyachen@ctrip.com>

Log config parameters about caller and stack trace do not work 'cos missing caller or stack trace option when initialize a zap logger object.
Its output may show as follow:
``` json
{"level":"error","ts":"2020-03-20T16:12:13.998+0800","caller":"paasapi/paasapi.go:88","msg":" doHttpRequestWithMetrics failed","stacktrace":"*****"}
```
 